### PR TITLE
Fix imports / param names for modern sklearn

### DIFF
--- a/skrules/datasets/credit_data.py
+++ b/skrules/datasets/credit_data.py
@@ -18,8 +18,9 @@ Science.
 
 import pandas as pd
 import numpy as np
-from sklearn.datasets.base import get_data_home, Bunch
-from sklearn.datasets.base import _fetch_remote, RemoteFileMetadata
+from sklearn.datasets import get_data_home
+from sklearn.utils import Bunch
+from sklearn.datasets._base import _fetch_remote, RemoteFileMetadata
 from os.path import exists, join
 
 

--- a/skrules/skope_rules.py
+++ b/skrules/skope_rules.py
@@ -8,7 +8,7 @@ from warnings import warn
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
 from sklearn.utils.multiclass import check_classification_targets
-from sklearn.utils import indices_to_mask
+from sklearn.utils._mask import indices_to_mask
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.ensemble import BaggingClassifier, BaggingRegressor
 from sklearn.tree import _tree
@@ -268,7 +268,7 @@ class SkopeRules(BaseEstimator):
 
         for max_depth in self._max_depths:
             bagging_clf = BaggingClassifier(
-                base_estimator=DecisionTreeClassifier(
+                estimator=DecisionTreeClassifier(
                     max_depth=max_depth,
                     max_features=self.max_features,
                     min_samples_split=self.min_samples_split),
@@ -285,7 +285,7 @@ class SkopeRules(BaseEstimator):
                 verbose=self.verbose)
 
             bagging_reg = BaggingRegressor(
-                base_estimator=DecisionTreeRegressor(
+                estimator=DecisionTreeRegressor(
                     max_depth=max_depth,
                     max_features=self.max_features,
                     min_samples_split=self.min_samples_split),


### PR DESCRIPTION
Quick fix of imports / param names to make compatible with modern sklearn and python 3.11